### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/recipe.yaml
+++ b/.github/workflows/recipe.yaml
@@ -63,6 +63,12 @@ jobs:
         run: |
           composer create-project --prefer-dist --no-scripts --no-progress --no-install sylius/sylius-standard sylius "${{ matrix.sylius }}"
 
+      # Because the sylius-standard has a soft constraint
+      - name: Make sure to install the required version of Sylius
+        working-directory: ./sylius
+        run: |
+            composer require --no-install --no-scripts --no-progress sylius/sylius="${{ matrix.sylius }}"
+
       - name: Setup some requirements
         working-directory: ./sylius
         run: |

--- a/.github/workflows/recipe.yaml
+++ b/.github/workflows/recipe.yaml
@@ -78,13 +78,6 @@ jobs:
             composer config secure-http false
             composer config --unset platform.php
 
-      - name: Install monsieurbiz/sylius-shipping-slot-plugin
-        working-directory: ./sylius
-        run: |
-          composer require monsieurbiz/sylius-shipping-slot-plugin="^1.0@RC" --no-install --no-update
-          sed -i -e "s/];/MonsieurBiz\\\SyliusShippingSlotPlugin\\\MonsieurBizSyliusShippingSlotPlugin::class => ['all' => true], ];/g" config/bundles.php
-          cp -Rv $PWD/../plugin/dist/* ./
-
       - name: Require plugin without install
         working-directory: ./sylius
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,6 +23,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
 
       - name: Setup PHP
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 SHELL=/bin/bash
 APP_DIR=tests/Application
-SYLIUS_VERSION=1.10
+SYLIUS_VERSION=1.10.0
 SYMFONY=cd ${APP_DIR} && symfony
 COMPOSER=symfony composer
 CONSOLE=${SYMFONY} console
@@ -62,18 +62,21 @@ ${APP_DIR}/node_modules: yarn.install
 application: .php-version php.ini ${APP_DIR} setup_application ${APP_DIR}/docker-compose.yaml
 
 ${APP_DIR}:
-	(${COMPOSER} create-project --prefer-dist --no-scripts --no-progress --no-install sylius/sylius-standard="${SYLIUS_VERSION}" ${APP_DIR})
+	(${COMPOSER} create-project --no-interaction --prefer-dist --no-scripts --no-progress --no-install sylius/sylius-standard="~${SYLIUS_VERSION}" ${APP_DIR})
 
 setup_application:
 	rm -f ${APP_DIR}/yarn.lock
 	(cd ${APP_DIR} && ${COMPOSER} config repositories.plugin '{"type": "path", "url": "../../"}')
 	(cd ${APP_DIR} && ${COMPOSER} config extra.symfony.allow-contrib true)
 	(cd ${APP_DIR} && ${COMPOSER} config minimum-stability dev)
-	(cd ${APP_DIR} && ${COMPOSER} require --no-scripts --no-progress --no-install --no-update monsieurbiz/${PLUGIN_NAME}="*@dev")
-	$(MAKE) apply_dist
+	(cd ${APP_DIR} && ${COMPOSER} require --no-install --no-scripts --no-progress sylius/sylius="~${SYLIUS_VERSION}") # Make sure to install the required version of sylius because the sylius-standard has a soft constraint
 	$(MAKE) ${APP_DIR}/.php-version
 	$(MAKE) ${APP_DIR}/php.ini
-	(cd ${APP_DIR} && ${COMPOSER} install)
+	(cd ${APP_DIR} && ${COMPOSER} install --no-interaction)
+	$(MAKE) apply_dist
+	(cd ${APP_DIR} && ${COMPOSER} require --no-interaction --no-progress monsieurbiz/${PLUGIN_NAME}="*@dev")
+	rm -rf ${APP_DIR}/var/cache
+
 
 ${APP_DIR}/docker-compose.yaml:
 	rm -f ${APP_DIR}/docker-compose.yml
@@ -182,6 +185,11 @@ docker.down: ## Stop and remove the docker containers
 docker.logs: ## Logs the docker containers
 	cd ${APP_DIR} && ${COMPOSE} logs -f
 .PHONY: docker.logs
+
+docker.dc: ARGS=ps
+docker.dc: ## Run docker-compose command. Use ARGS="" to pass parameters to docker-compose.
+	cd ${APP_DIR} && ${COMPOSE} ${ARGS}
+.PHONY: docker.dc
 
 server.start: ## Run the local webserver using Symfony
 	${SYMFONY} local:server:start -d

--- a/composer.json
+++ b/composer.json
@@ -45,9 +45,6 @@
         "symfony/web-profiler-bundle": "^4.4",
         "phpmd/phpmd": "@stable"
     },
-    "conflict": {
-        "doctrine/dbal": "^3"
-    },
     "prefer-stable": true,
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- remove the temporary conflict with doctrine/dbal (fix in sylius)
- add node version in test workflow
- force the sylius version and remove the shipping-slot installation (use dependency and flex recipe) in recipe workflow
- improvements in makefile:
    - allow to install the latest minor version
    - fix the sylius version because the sylius-standard has a soft constraint
    - install sylius before the plugin is required